### PR TITLE
Added OS X compatibility (and explanation)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -297,6 +297,30 @@ The script also supports [uploading to Github](https://developer.github.com/v3/r
 
 # Appendix
 
+## OS X (BSD?) compatibility
+
+The script was developed with a Linux system in mind and the BSD-like OS X offers different utilities which need to be mapped/replaced.
+
+Note that these changes assume that you are using https://brew.sh/
+
+First, install a few requirements:
+
+```
+brew install bash gnu-getopt coreutils
+brew link --force gnu-getopt
+```
+
+Second, add some symlinks to make the system more Linux-like:
+```
+ln -s /usr/local/bin/gsha512sum /usr/local/bin/sha512sum
+ln -s /usr/local/bin/gsha526sum /usr/local/bin/sha256sum
+```
+
+Lastly, depending on your environment, your `PATH` might need a change:
+```
+export PATH=/usr/local/bin:$PATH
+```
+
 ## Email Encryption
 You can also use your GPG key for email encryption with [enigmail and thunderbird](https://wiki.archlinux.org/index.php/thunderbird#EnigMail_-_Encryption). [[Read more]](https://www.enigmail.net/index.php/en/)
 

--- a/gpgit.sh
+++ b/gpgit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VERSION="1.3.0"
 
 # Avoid any encoding problems


### PR DESCRIPTION
It's still not a walk in the park but should be doable now.

Better would be to replace the commands within the script so these steps aren't needed.

1. If the script would use `shasum -a 512` instead of `sha512sum` it would work just fine on both Linux and OS X.
2. If the script would try `/usr/local/Cellar/gnu-getopt/*/bin/getopt` before the regular `getopt` it would fix that symlink as well.
