### PR TITLE
Update Arch Linux package URL in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ The security status of GNU/Linux projects will be tracked in the [Linux Security
 
 ### Arch Linux
 
-GPGit is available as [official Arch Linux distribution package](https://archlinux.org/packages/community/any/gpgit/):
+GPGit is available as [official Arch Linux distribution package](https://archlinux.org/packages/extra/any/gpgit/):
 
 ```bash
 sudo pacman -S gpgit


### PR DESCRIPTION
The old URL returns 404 now.